### PR TITLE
Updated chapter 3 pom because pentaho artifactory url was deprecated.

### DIFF
--- a/Chapter03/pentaho-reporting-web-app/pom.xml
+++ b/Chapter03/pentaho-reporting-web-app/pom.xml
@@ -7,10 +7,13 @@
   <version>1.0-SNAPSHOT</version>
   <name>pentaho-reporting-web-app Maven Webapp</name>
   <url>http://maven.apache.org</url>
+  <properties>
+    <pentaho-version>7.1-QAT-217</pentaho-version>
+  </properties>
   <repositories>
     <repository>
       <id>pentaho-releases</id>
-      <url>http://repository.pentaho.org/artifactory/repo/</url>
+      <url>http://nexus.pentaho.org/content/groups/omni</url>
     </repository>
   </repositories>
   <dependencies>
@@ -28,62 +31,62 @@
     <dependency>
       <groupId>pentaho-reporting-engine</groupId>
       <artifactId>pentaho-reporting-engine-classic-core</artifactId>
-      <version>8.0-SNAPSHOT</version>
+      <version>${pentaho-version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho-reporting-engine</groupId>
       <artifactId>pentaho-reporting-engine-classic-extensions</artifactId>
-      <version>8.0-SNAPSHOT</version>
+      <version>${pentaho-version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho-reporting-engine</groupId>
       <artifactId>pentaho-reporting-engine-wizard-core</artifactId>
-      <version>8.0-SNAPSHOT</version>
+      <version>${pentaho-version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho-library</groupId>
       <artifactId>libbase</artifactId>
-      <version>8.0-SNAPSHOT</version>
+      <version>${pentaho-version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho-library</groupId>
       <artifactId>libdocbundle</artifactId>
-      <version>8.0-SNAPSHOT</version>
+      <version>${pentaho-version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho-library</groupId>
       <artifactId>libfonts</artifactId>
-      <version>8.0-SNAPSHOT</version>
+      <version>${pentaho-version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho-library</groupId>
       <artifactId>libformat</artifactId>
-      <version>8.0-SNAPSHOT</version>
-    </dependency>    
+      <version>${pentaho-version}</version>
+    </dependency>
     <dependency>
       <groupId>pentaho-library</groupId>
       <artifactId>libformula</artifactId>
-      <version>8.0-SNAPSHOT</version>
-    </dependency>             
+      <version>${pentaho-version}</version>
+    </dependency>
     <dependency>
       <groupId>pentaho-library</groupId>
       <artifactId>libloader</artifactId>
-      <version>8.0-SNAPSHOT</version>
+      <version>${pentaho-version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho-library</groupId>
       <artifactId>librepository</artifactId>
-      <version>8.0-SNAPSHOT</version>
-    </dependency>        
+      <version>${pentaho-version}</version>
+    </dependency>
     <dependency>
       <groupId>pentaho-library</groupId>
       <artifactId>libserializer</artifactId>
-      <version>8.0-SNAPSHOT</version>
+      <version>${pentaho-version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho-library</groupId>
       <artifactId>libxml</artifactId>
-      <version>8.0-SNAPSHOT</version>
+      <version>${pentaho-version}</version>
     </dependency>
     <dependency>
       <groupId>com.lowagie</groupId>


### PR DESCRIPTION
When following [the previous artifactory url](http://repository.pentaho.org/artifactory/repo/), you can see that it is deprecated, and you can get the new url.

Since the version is no longer 8.0-SNAPSHOT, I parametrized it for better maintaining.